### PR TITLE
Removed local buffering from functions

### DIFF
--- a/src/vsftp_filesystem.c
+++ b/src/vsftp_filesystem.c
@@ -46,7 +46,7 @@ static int ConcatCwdAndPath(const char *cwd, const size_t cwdLen, const char *pa
     return retval;
 }
 
-int VSFTPFilesystemListDirPerFile(const char *path, size_t pathLen, char *buf, size_t size, size_t *bufLen,
+int VSFTPFilesystemListDirPerLine(const char *path, size_t pathLen, char *buf, size_t size, size_t *bufLen,
                                   bool prependDir, void **cookie)
 {
     struct dirent *ldir = NULL;
@@ -256,4 +256,3 @@ int VSFTPFilesystemCloseFile(const int fd)
 {
     return close(fd);
 }
-

--- a/src/vsftp_filesystem.h
+++ b/src/vsftp_filesystem.h
@@ -17,7 +17,7 @@
 #ifndef VSFTP_FILESYSTEM_H__
 #define VSFTP_FILESYSTEM_H__
 
-extern int VSFTPFilesystemListDirPerFile(const char *path, size_t pathLen, char *buf, size_t size, size_t *bufLen,
+extern int VSFTPFilesystemListDirPerLine(const char *path, size_t pathLen, char *buf, size_t size, size_t *bufLen,
                                          bool prependDir, void **cookie);
 extern int VSFTPFilesystemIsDir(const char *dir, const size_t dirLen);
 extern int VSFTPFilesystemIsFile(const char *file, const size_t fileLen);

--- a/src/vsftp_server.c
+++ b/src/vsftp_server.c
@@ -16,6 +16,7 @@
 */
 
 #include <stdlib.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <string.h>
 #include <stdarg.h>
@@ -610,7 +611,7 @@ int VSFTPServerGetTransferMode(bool *binary)
 int VSFTPServerListDirPerFile(const char *dir, size_t len, char *buf, size_t size, size_t *bufLen,
                               bool prependDir, void **cookie)
 {
-    return VSFTPFilesystemListDirPerFile(dir, len, buf, size, bufLen, prependDir, cookie);
+    return VSFTPFilesystemListDirPerLine(dir, len, buf, size, bufLen, prependDir, cookie);
 }
 
 int VSFTPServerGetServerIP4(char *buf, const size_t size)


### PR DESCRIPTION
```
Only required to be done when going to change system CWD (f.e.).
Add more checks to filesystem functions.
```
Closes #8 