### PR TITLE
Remove duplicate \r\n at the end of the size answer

### DIFF
--- a/src/common/vsftp_commands.c
+++ b/src/common/vsftp_commands.c
@@ -388,7 +388,7 @@ static int CommandHandlerSize(const char *args, size_t len)
     }
 
     if (retval == 0) {
-        retval = VSFTPServerSendReply("213 %llu\r\n", (unsigned long long int)filestats.st_size);
+        retval = VSFTPServerSendReply("213 %llu", (unsigned long long int)filestats.st_size);
     } else {
         retval = VSFTPServerSendReply(isFileError == true ? fileNotFound : localError);
     }


### PR DESCRIPTION
Caused issues in the (p)ftp client on the second request.